### PR TITLE
Add getDeviceUsage

### DIFF
--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -344,3 +344,29 @@ class P100():
 			errorCode = ast.literal_eval(decryptedResponse)["error_code"]
 			errorMessage = self.errorCodes[str(errorCode)]
 			raise Exception(f"Error Code: {errorCode}, {errorMessage}")
+
+	def getDeviceUsage(self):
+		URL = f"http://{self.ipAddress}/app?token={self.token}"
+		Payload = {
+			"method": "get_device_usage",
+			"params": {},
+			"requestTimeMils": int(round(time.time() * 1000)),
+		}
+
+		headers = {
+			"Cookie": self.cookie
+		}
+
+		EncryptedPayload = self.tpLinkCipher.encrypt(json.dumps(Payload))
+
+		SecurePassthroughPayload = {
+			"method": "securePassthrough",
+			"params":{
+				"request": EncryptedPayload
+			}
+		}
+
+		r = self.session.post(URL, json=SecurePassthroughPayload, headers=headers)
+		decryptedResponse = self.tpLinkCipher.decrypt(r.json()["result"]["response"])
+
+		return json.loads(decryptedResponse)


### PR DESCRIPTION
getDeviceUsage returns `time_usage` (in minutes) and `power_usage` (actually cumulative energy in Wh) over {today, 7 days, 30 days} for L530 bulb and P110 socket.

(I haven't actually tested on a P100 socket)